### PR TITLE
Add Global AI and Sodexo branding to header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,8 @@ import {
   Pie,
   Cell,
 } from "recharts";
+import globalAiLogo from "./assets/global-ai-logo.svg";
+import sodexoLogo from "./assets/sodexo-logo.svg";
 
 const months = Array.from({ length: 12 }).map((_, i) => new Date(2024, i, 1).toLocaleString("en", { month: "short" }));
 const adoptionSeries = months.map((month, i) => ({
@@ -263,7 +265,26 @@ function Shell({ children }: { children: React.ReactNode }) {
           </button>
           <Gauge size={22} />
           <div className="font-semibold">Business Control Center</div>
-          <div className="ml-auto text-sm text-[#555]">{title}</div>
+          <div className="ml-auto flex flex-wrap items-center gap-3 sm:gap-5 justify-end text-[#555]">
+            <div className="text-xs sm:text-sm font-medium whitespace-nowrap">{title}</div>
+            <div className="flex items-center gap-2">
+              <span className="text-[10px] sm:text-xs uppercase tracking-wide text-[#777]">Platform</span>
+              <img
+                src={globalAiLogo}
+                alt="Global AI logo"
+                className="h-6 w-auto object-contain"
+              />
+            </div>
+            <span className="hidden sm:block h-6 w-px bg-[#ddd]" aria-hidden="true" />
+            <div className="flex items-center gap-2">
+              <span className="text-[10px] sm:text-xs uppercase tracking-wide text-[#777]">Client</span>
+              <img
+                src={sodexoLogo}
+                alt="Sodexo logo"
+                className="h-6 w-auto object-contain"
+              />
+            </div>
+          </div>
         </div>
       </header>
 

--- a/src/assets/global-ai-logo.svg
+++ b/src/assets/global-ai-logo.svg
@@ -1,0 +1,10 @@
+<svg width="160" height="40" viewBox="0 0 160 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g>
+    <circle cx="22" cy="20" r="18" fill="#4338CA" />
+    <path d="M10 14L20.8 24.8" stroke="white" stroke-width="3" stroke-linecap="round" />
+    <path d="M14 10L24.8 20.8" stroke="#C7D2FE" stroke-width="2" stroke-linecap="round" />
+    <path d="M18 8L28 18" stroke="#EEF2FF" stroke-width="2" stroke-linecap="round" />
+  </g>
+  <text x="46" y="25" fill="#111827" font-size="18" font-weight="600" font-family="'Segoe UI', Arial, sans-serif">Global</text>
+  <text x="112" y="25" fill="#4338CA" font-size="18" font-weight="700" font-family="'Segoe UI', Arial, sans-serif">AI</text>
+</svg>

--- a/src/assets/sodexo-logo.svg
+++ b/src/assets/sodexo-logo.svg
@@ -1,0 +1,5 @@
+<svg width="200" height="40" viewBox="0 0 200 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <text x="0" y="26" fill="#0B3D91" font-size="24" font-weight="600" font-family="'Segoe UI', Arial, sans-serif">sodexo</text>
+  <path d="M58 30C85 38 126 34 146 24" stroke="#E83B2D" stroke-width="4" stroke-linecap="round" />
+  <path d="M162 6L165 15H174L167 20.5L169.5 29L162 23.5L154.5 29L157 20.5L150 15H159L162 6Z" fill="#0B3D91" />
+</svg>


### PR DESCRIPTION
## Summary
- import platform and client branding assets and surface them in the control center header
- add custom SVG assets for the Global AI platform and Sodexo client logos with transparent backgrounds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d45ae93cdc832bbaf2d1a497dd77a0