### PR TITLE
Update header branding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -246,7 +246,7 @@ function usePageTitle() {
     "/quality": "Quality & Risk",
     "/engagement": "Engagement & Change Mgmt",
   };
-  return map[pathname] ?? "Business Control Center";
+  return map[pathname] ?? "Global AI Business Control Center";
 }
 
 function Shell({ children }: { children: React.ReactNode }) {
@@ -264,11 +264,10 @@ function Shell({ children }: { children: React.ReactNode }) {
             {open ? <X size={18} /> : <Menu size={18} />}
           </button>
           <Gauge size={22} />
-          <div className="font-semibold">Business Control Center</div>
+          <div className="font-semibold">Global AI Business Control Center</div>
           <div className="ml-auto flex flex-wrap items-center gap-3 sm:gap-5 justify-end text-[#555]">
             <div className="text-xs sm:text-sm font-medium whitespace-nowrap">{title}</div>
             <div className="flex items-center gap-2">
-              <span className="text-[10px] sm:text-xs uppercase tracking-wide text-[#777]">Platform</span>
               <img
                 src={globalAiLogo}
                 alt="Global AI logo"
@@ -277,7 +276,6 @@ function Shell({ children }: { children: React.ReactNode }) {
             </div>
             <span className="hidden sm:block h-6 w-px bg-[#ddd]" aria-hidden="true" />
             <div className="flex items-center gap-2">
-              <span className="text-[10px] sm:text-xs uppercase tracking-wide text-[#777]">Client</span>
               <img
                 src={sodexoLogo}
                 alt="Sodexo logo"


### PR DESCRIPTION
## Summary
- rename the shell header title to "Global AI Business Control Center"
- remove the "Platform" and "Client" labels so the header shows only the partner logos
- align the default page title with the updated control center name

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d51ad4bf34832bbcb3149e42c46fbc