### PR TITLE
Remove Global AI branding from header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,6 @@ import {
   Pie,
   Cell,
 } from "recharts";
-import globalAiLogo from "./assets/global-ai-logo.svg";
 import sodexoLogo from "./assets/sodexo-logo.svg";
 
 const months = Array.from({ length: 12 }).map((_, i) => new Date(2024, i, 1).toLocaleString("en", { month: "short" }));
@@ -272,13 +271,6 @@ function Shell({ children }: { children: React.ReactNode }) {
           <div className="font-semibold">Global AI Business Control Center</div>
           <div className="ml-auto flex flex-wrap items-center gap-3 sm:gap-5 justify-end text-[#555]">
             <div className="text-xs sm:text-sm font-medium whitespace-nowrap">{title}</div>
-            <div className="flex items-center gap-2">
-              <img
-                src={globalAiLogo}
-                alt="Global AI logo"
-                className="h-6 w-auto object-contain"
-              />
-            </div>
             <span className="hidden sm:block h-6 w-px bg-[#ddd]" aria-hidden="true" />
             <div className="flex items-center gap-2">
               <img


### PR DESCRIPTION
## Summary
- remove the Global AI logo from the dashboard header while keeping the rest of the layout intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d66d015454832b8cb1e135b68f9675